### PR TITLE
Migrate to Twilio SDK v8.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
         <jruby.version>1.3.0</jruby.version>
         <org.testng.version>6.1.1</org.testng.version>
         <integration.base.version>1.0.1</integration.base.version>
+        <jackson.core.asl.version>1.9.8</jackson.core.asl.version>
+        <jackson.mapper.asl.version>1.9.8</jackson.mapper.asl.version>
+        <twilio.version>8.36.0</twilio.version>
+        <jackson.datatype.jsr310.version>2.13.4</jackson.datatype.jsr310.version>
+        <jackson.databind.version>2.13.4</jackson.databind.version>
     </properties>
     <dependencies>
         <dependency>
@@ -137,17 +142,29 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.8</version>
+            <version>${jackson.core.asl.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.8</version>
+            <version>${jackson.mapper.asl.version}</version>
         </dependency>
         <dependency>
             <groupId>com.twilio.sdk</groupId>
-            <artifactId>twilio-java-sdk</artifactId>
-            <version>3.3.13</version>
+            <artifactId>twilio</artifactId>
+            <version>${twilio.version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.datatype.jsr310.version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
     <scm>
@@ -163,8 +180,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/assembly/assemble-connector.xml
+++ b/src/main/assembly/assemble-connector.xml
@@ -27,7 +27,9 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>com.twilio.sdk:twilio-java-sdk</include>
+                <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+                <include>com.fasterxml.jackson.core:jackson-databind</include>
+                <include>com.twilio.sdk:twilio</include>
                 <include>org.codehaus.jackson:jackson-core-asl</include>
                 <include>org.codehaus.jackson:jackson-mapper-asl</include>
             </includes>

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/getApplication.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/getApplication.java
@@ -19,14 +19,17 @@ package org.wso2.carbon.connector.twilio.application;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting an application instance based on the
@@ -42,28 +45,21 @@ public class getApplication extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_APPLICATION_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_APPLICATIONS +
-                                    "/" + applicationId,
-                            "GET", null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_APPLICATIONS +
+                        "/" + applicationId
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get application");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/getAuthorizedConnectApp.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/getAuthorizedConnectApp.java
@@ -19,14 +19,17 @@ package org.wso2.carbon.connector.twilio.application;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
 * Class mediator for getting an authorized connect app instance based on the ApplicationSid parameter
@@ -40,28 +43,22 @@ public class getAuthorizedConnectApp extends AbstractConnector {
         String applicationId =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_AUTHORIZED_CONNECT_APP_SID);
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_AUTHORIZED_CONNECT_APPS +
-                                    "/" + applicationId,
-                            "GET", null);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_AUTHORIZED_CONNECT_APPS +
+                        "/" + applicationId
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get authorized connect app");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/getAuthorizedConnectAppList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/getAuthorizedConnectAppList.java
@@ -19,13 +19,16 @@ package org.wso2.carbon.connector.twilio.application;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a list of authorized connect app instances
@@ -37,27 +40,20 @@ public class getAuthorizedConnectAppList extends AbstractConnector {
     public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get authorized connect app list");
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_AUTHORIZED_CONNECT_APPS,
-                            "GET", null);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_AUTHORIZED_CONNECT_APPS);
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get authorized connect app list");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/getConnectApp.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/getConnectApp.java
@@ -19,14 +19,17 @@ package org.wso2.carbon.connector.twilio.application;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a connect app instance based on the ConnectAppSid
@@ -42,28 +45,21 @@ public class getConnectApp extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_CONNECT_APP_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_AUTHORIZED_CONNECT_APPS +
-                                    "/" + connectId, "GET",
-                            null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_CONNECT_APPS +
+                        "/" + connectId
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get connect app");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/getConnectAppList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/getConnectAppList.java
@@ -19,13 +19,16 @@ package org.wso2.carbon.connector.twilio.application;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a list of connect app instances
@@ -36,27 +39,20 @@ public class getConnectAppList extends AbstractConnector {
     public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get connect app list");
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_CONNECT_APPS,
-                            "GET", null);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_CONNECT_APPS);
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get connect app list");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/application/updateApplication.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/application/updateApplication.java
@@ -17,19 +17,18 @@
  */
 package org.wso2.carbon.connector.twilio.application;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.resource.instance.Application;
+import com.twilio.http.HttpMethod;
+import com.twilio.rest.api.v2010.account.Application;
+import com.twilio.rest.api.v2010.account.ApplicationUpdater;
 
 /*
 * Class mediator for updating an application instance with optional parameters
@@ -40,25 +39,18 @@ public class updateApplication extends AbstractConnector {
     public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: update application");
-        Map<String, String> params = createParameterMap(messageContext);
         String applicationSid =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_APPLICATION_SID);
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            // creating a new application under the specified AccountSID
-            Application application = twilioRestClient.getAccount().getApplication(applicationSid);
-            //update the relevant application
-            application.update(params);
-            OMElement omResponse = TwilioUtil.parseResponse("application.update.success");
-            TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_APPLICATION_SID,
-                    application.getSid());
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0002", messageContext);
-            throw new SynapseException(e);
-        }
+
+        TwilioUtil.initTwilio(messageContext);
+        ApplicationUpdater applicationUpdater = getApplicationUpdater(messageContext, applicationSid);
+        Application application = applicationUpdater.update();
+        OMElement omResponse = TwilioUtil.parseResponse("application.update.success");
+        TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_APPLICATION_SID,
+                application.getSid());
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: update application");
     }
 
@@ -68,14 +60,12 @@ public class updateApplication extends AbstractConnector {
      *
      * @return The map containing the defined parameters
      */
-    private Map<String, String> createParameterMap(MessageContext messageContext) {
-        // Required
+    private ApplicationUpdater getApplicationUpdater(MessageContext messageContext, String applicationSid) {
+        ApplicationUpdater applicationUpdater = Application.updater(applicationSid);
+        // optional parameters for creating the application
         String friendlyName =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_FRIENDLY_NAME);
-        // optional parameters for creating the application retrieved by the
-        // Sid. See
-        // http://www.twilio.com/docs/api/rest/applications#list-post-optional-parameters
         String apiVersion =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_API_VERSION);
@@ -116,50 +106,49 @@ public class updateApplication extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_SMS_STATUS_CALLBACK);
 
-        // creating the map for optional parameters
-        Map<String, String> params = new HashMap<String, String>();
-        params.put(TwilioUtil.TWILIO_FRIENDLY_NAME, friendlyName);
-
         // null-checking and addition to map
+        if (friendlyName != null) {
+            applicationUpdater.setFriendlyName(friendlyName);
+        }
         if (apiVersion != null) {
-            params.put(TwilioUtil.TWILIO_API_VERSION, apiVersion);
+            applicationUpdater.setApiVersion(apiVersion);
         }
         if (voiceUrl != null) {
-            params.put(TwilioUtil.TWILIO_VOICE_URL, voiceUrl);
+            applicationUpdater.setVoiceUrl(URI.create(voiceUrl));
         }
         if (voiceMethod != null) {
-            params.put(TwilioUtil.TWILIO_VOICE_METHOD, voiceMethod);
+            applicationUpdater.setVoiceMethod(HttpMethod.valueOf(voiceMethod));
         }
         if (voiceFallbackUrl != null) {
-            params.put(TwilioUtil.TWILIO_VOICE_FALLBACKURL, voiceFallbackUrl);
+            applicationUpdater.setVoiceFallbackUrl(URI.create(voiceFallbackUrl));
         }
         if (voiceFallbackMethod != null) {
-            params.put(TwilioUtil.TWILIO_VOICE_FALLBACKMETHOD, voiceFallbackMethod);
+            applicationUpdater.setVoiceFallbackMethod(HttpMethod.valueOf(voiceFallbackMethod));
         }
         if (statusCallback != null) {
-            params.put(TwilioUtil.TWILIO_STATUS_CALLBACK, statusCallback);
+            applicationUpdater.setStatusCallback(URI.create(statusCallback));
         }
         if (statusCallbackMethod != null) {
-            params.put(TwilioUtil.TWILIO_STATUS_CALLBACKMETHOD, statusCallbackMethod);
+            applicationUpdater.setStatusCallbackMethod(HttpMethod.valueOf(statusCallbackMethod));
         }
         if (voiceCallerIdLookup != null) {
-            params.put(TwilioUtil.TWILIO_VOICE_CALLERID_LOOKUP, voiceCallerIdLookup);
+            applicationUpdater.setVoiceCallerIdLookup(Boolean.parseBoolean(voiceCallerIdLookup));
         }
         if (smsUrl != null) {
-            params.put(TwilioUtil.TWILIO_SMS_URL, smsUrl);
+            applicationUpdater.setSmsUrl(URI.create(smsUrl));
         }
         if (smsMethod != null) {
-            params.put(TwilioUtil.TWILIO_SMS_METHOD, smsMethod);
+            applicationUpdater.setSmsMethod(HttpMethod.valueOf(smsMethod));
         }
         if (smsFallbackUrl != null) {
-            params.put(TwilioUtil.TWILIO_SMS_FALLBACKURL, smsFallbackUrl);
+            applicationUpdater.setSmsFallbackUrl(URI.create(smsFallbackUrl));
         }
         if (smsFallbackMethod != null) {
-            params.put(TwilioUtil.TWILIO_SMS_FALLBACKMETHOD, smsFallbackMethod);
+            applicationUpdater.setSmsFallbackMethod(HttpMethod.valueOf(smsFallbackMethod));
         }
         if (smsStatusCallback != null) {
-            params.put(TwilioUtil.TWILIO_SMS_STATUS_CALLBACK, smsStatusCallback);
+            applicationUpdater.setSmsStatusCallback(URI.create(smsStatusCallback));
         }
-        return params;
+        return applicationUpdater;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/call/GetCall.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/call/GetCall.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.call;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a Call instance based on its Sid.
@@ -36,34 +38,30 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetCall extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get call");
+
         String callSid =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_CALL_SID);
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_CALLS +
-                                    "/" + callSid, "GET",
-                            null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0003", messageContext);
-            throw new SynapseException(e);
-        }
+
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_CALLS +
+                        "/" + callSid
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get call");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/call/GetRecording.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/call/GetRecording.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.call;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a recording instance based on its Sid.
@@ -36,34 +38,29 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetRecording extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get recording");
         // Get parameters from the messageContext
         String recordingSid =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_RECORDING_SID);
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_RECORDINGS +
-                                    "/" + recordingSid,
-                            "GET", null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0003", messageContext);
-            throw new SynapseException(e);
-        }
+
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_RECORDINGS +
+                        "/" + recordingSid
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get recording");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/call/GetTranscription.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/call/GetTranscription.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.call;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a call transcription.
@@ -36,34 +38,29 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetTranscription extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get transcription");
         // Get parameters from the messageContext
         String transcriptionSid =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_TRANSCRIPTION_SID);
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_TRANSCRIPTIONS +
-                                    "/" + transcriptionSid,
-                            "GET", null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0003", messageContext);
-            throw new SynapseException(e);
-        }
+
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_TRANSCRIPTIONS +
+                        "/" + transcriptionSid
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get transcription");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/call/GetTranscriptionList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/call/GetTranscriptionList.java
@@ -19,14 +19,16 @@ package org.wso2.carbon.connector.twilio.call;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a call transcription.
@@ -35,30 +37,24 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetTranscriptionList extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get transcription list");
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_TRANSCRIPTIONS,
-                            "GET", null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0003", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_TRANSCRIPTIONS
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get transcription list");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/conference/GetConference.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/conference/GetConference.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.conference;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting Conference instance based on its Sid.
@@ -35,31 +37,28 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetConference extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get conference");
         // Get the conference Sid
-        String conferenceSid = (String) ConnectorUtils.lookupTemplateParamater(messageContext, TwilioUtil.PARAM_CONFERENCE_SID);
+        String conferenceSid = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                TwilioUtil.PARAM_CONFERENCE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response = twilioRestClient.request(TwilioUtil.API_URL + "/" +
-                    TwilioUtil.API_VERSION + "/" +
-                    TwilioUtil.API_ACCOUNTS +
-                    "/" +
-                    twilioRestClient.getAccountSid() +
-                    "/" +
-                    TwilioUtil.API_CONFERENCES +
-                    "/" + conferenceSid, "GET", null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_CONFERENCES +
+                        "/" + conferenceSid);
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0004", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get conference");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/conference/GetParticipant.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/conference/GetParticipant.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.conference;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a participant of a given conference.
@@ -37,7 +39,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetParticipant extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get conference participant");
@@ -49,32 +51,25 @@ public class GetParticipant extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_CALL_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_CONFERENCES +
-                                    "/" +
-                                    conferenceSid +
-                                    "/" +
-                                    TwilioUtil.API_PARTICIPANTS +
-                                    "/" + callSid, "GET",
-                            null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_CONFERENCES +
+                        "/" +
+                        conferenceSid +
+                        "/" +
+                        TwilioUtil.API_PARTICIPANTS +
+                        "/" + callSid
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0004", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get conference participant");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetIncomingPhoneNumber.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetIncomingPhoneNumber.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.phonenumbers;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting the list of incoming phone numbers.
@@ -37,7 +39,7 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetIncomingPhoneNumber extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get incoming phone");
@@ -46,27 +48,21 @@ public class GetIncomingPhoneNumber extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_INCOMING_PHONE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_INCOMING_PHONENUMBER +
-                                    "/" + phoneNumberSid,
-                            "GET", null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0005", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_INCOMING_PHONENUMBER +
+                        "/" + phoneNumberSid
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get incoming phone");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetIncomingPhoneNumberList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetIncomingPhoneNumberList.java
@@ -17,20 +17,19 @@
  */
 package org.wso2.carbon.connector.twilio.phonenumbers;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting the list of incoming phone numbers.
@@ -40,11 +39,30 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetIncomingPhoneNumberList extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get incoming phone list");
-        // Parameters for the filters
+
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_INCOMING_PHONENUMBER
+        );
+        addQueryParams(request, messageContext);
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
+        log.auditLog("End: get incoming phone list");
+    }
+
+    private void addQueryParams(Request request, MessageContext messageContext) {
         String phoneNumber =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_PHONENUMBER);
@@ -52,34 +70,11 @@ public class GetIncomingPhoneNumberList extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_FRIENDLY_NAME);
 
-        Map<String, String> params = new HashMap<String, String>();
         if (phoneNumber != null) {
-            params.put(TwilioUtil.TWILIO_PHONENUMBER, phoneNumber);
+            request.addQueryParam(TwilioUtil.TWILIO_PHONENUMBER, phoneNumber);
         }
         if (friendlyName != null) {
-            params.put(TwilioUtil.TWILIO_FRIENDLY_NAME, friendlyName);
+            request.addQueryParam(TwilioUtil.TWILIO_FRIENDLY_NAME, friendlyName);
         }
-
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_INCOMING_PHONENUMBER,
-                            "GET", params);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0005", messageContext);
-            throw new SynapseException(e);
-        }
-        log.auditLog("End: get incoming phone list");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetOutgoingPhoneNumber.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/GetOutgoingPhoneNumber.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.phonenumbers;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting the list of incoming phone numbers.
@@ -37,7 +39,7 @@ import com.twilio.sdk.TwilioRestResponse;
 public class GetOutgoingPhoneNumber extends AbstractConnector {
 
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get outgoing phone");
@@ -46,27 +48,21 @@ public class GetOutgoingPhoneNumber extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_OUTGOING_PHONE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_OUTGOING_PHONENUMBER +
-                                    "/" + phoneNumberSid,
-                            "GET", null);
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0005", messageContext);
-            throw new SynapseException(e);
-        }
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_OUTGOING_PHONENUMBER +
+                        "/" + phoneNumberSid
+        );
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get outgoing phone");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/RemoveIncomingPhoneNumber.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/phonenumbers/RemoveIncomingPhoneNumber.java
@@ -19,32 +19,21 @@ package org.wso2.carbon.connector.twilio.phonenumbers;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.resource.instance.IncomingPhoneNumber;
-
+import com.twilio.rest.api.v2010.account.IncomingPhoneNumber;
+import com.twilio.rest.api.v2010.account.IncomingPhoneNumberDeleter;
 /*
  * Class mediator for removing an incoming a phone numbers.
  * For more information, see
  * http://www.twilio.com/docs/api/rest/incoming-phone-numbers#instance-delete
  */
 public class RemoveIncomingPhoneNumber extends AbstractConnector {
-
-    // //Authorization details
-    // private String accountSid;
-    // private String authToken;
-    //
-    // //Sid of the required number
-    // private String incomingPhoneNumberSid;
-
     @Override
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: remove phone number");
@@ -54,27 +43,18 @@ public class RemoveIncomingPhoneNumber extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_INCOMING_PHONE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            // Get an incoming phone number allocated to the Twilio account by
-            // its Sid.
-            IncomingPhoneNumber number =
-                    twilioRestClient.getAccount()
-                            .getIncomingPhoneNumber(incomingPhoneNumberSid);
-            OMElement omResponse = null;
-            if (number.delete()) {
-                omResponse = TwilioUtil.parseResponse("phonenumber.delete.success");
-            } else {
-                omResponse = TwilioUtil.parseResponse("phonenumber.delete.fail");
-            }
-
-            TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_INCOMING_PHONE_SID, number.getSid());
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0005", messageContext);
-            throw new SynapseException(e);
+        TwilioUtil.initTwilio(messageContext);
+        IncomingPhoneNumberDeleter incomingPhoneNumberDeleter = IncomingPhoneNumber.deleter(incomingPhoneNumberSid);
+        OMElement omResponse;
+        if (incomingPhoneNumberDeleter.delete()) {
+            omResponse = TwilioUtil.parseResponse("phonenumber.delete.success");
+        } else {
+            omResponse = TwilioUtil.parseResponse("phonenumber.delete.fail");
         }
+
+        TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_INCOMING_PHONE_SID, incomingPhoneNumberSid);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: remove phone number");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/queue/GetMember.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/queue/GetMember.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.queue;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a member based on its callSid parameter
@@ -35,7 +37,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetMember extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get member");
 
@@ -46,30 +48,23 @@ public class GetMember extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_CALL_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_QUEUES +
-                                    "/" + queueSid + "/" +
-                                    TwilioUtil.API_MEMBERS +
-                                    "/" + callSid, "GET",
-                            null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_QUEUES +
+                        "/" + queueSid + "/" +
+                        TwilioUtil.API_MEMBERS +
+                        "/" + callSid
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0006", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get member");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/queue/GetQueue.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/queue/GetQueue.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.queue;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a queue instance based on the QueueSid parameter
@@ -35,7 +37,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetQueue extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get queue");
 
@@ -43,28 +45,21 @@ public class GetQueue extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_QUEUE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_QUEUES +
-                                    "/" + queueSid, "GET",
-                            null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_QUEUES +
+                        "/" + queueSid
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0006", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get queue");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/queue/GetQueueList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/queue/GetQueueList.java
@@ -19,42 +19,37 @@ package org.wso2.carbon.connector.twilio.queue;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 public class GetQueueList extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get queue list");
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_QUEUES,
-                            "GET", null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_QUEUES
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e);
-            TwilioUtil.handleException(e, "0006", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get queue list");
     }
 

--- a/src/main/java/org/wso2/carbon/connector/twilio/queue/UpdateQueue.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/queue/UpdateQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  * 
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,28 +17,22 @@
  */
 package org.wso2.carbon.connector.twilio.queue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.resource.instance.Queue;
-
+import com.twilio.rest.api.v2010.account.Queue;
+import com.twilio.rest.api.v2010.account.QueueUpdater;
 /*
  * Class mediator for updating a queue instance
  * For more information, see http://www.twilio.com/docs/api/rest/queue
  */
 public class UpdateQueue extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: update queue");
@@ -53,28 +47,22 @@ public class UpdateQueue extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_MAX_SIZE);
 
-        Map<String, String> params = new HashMap<String, String>();
+        TwilioUtil.initTwilio(messageContext);
+        QueueUpdater queueUpdater = Queue.updater(queueSid);
+
         if (friendlyName != null) {
-            params.put(TwilioUtil.TWILIO_FRIENDLY_NAME, friendlyName);
+            queueUpdater.setFriendlyName(friendlyName);
         }
         if (maxSize != null) {
-            params.put(TwilioUtil.TWILIO_MAX_SIZE, maxSize);
+            queueUpdater.setMaxSize(Integer.parseInt(maxSize));
         }
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
+        Queue queue = queueUpdater.update();
 
-            Queue queue = twilioRestClient.getAccount().getQueue(queueSid);
-            queue.update(params);
+        OMElement omResponse = TwilioUtil.parseResponse("queue.update.success");
+        TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_QUEUE_SID, queue.getSid());
+        TwilioUtil.preparePayload(messageContext, omResponse);
 
-            OMElement omResponse = TwilioUtil.parseResponse("queue.update.success");
-            TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_QUEUE_SID, queue.getSid());
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0006", messageContext);
-            throw new SynapseException(e);
-        }
         log.auditLog("End: update queue");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/sms/GetShortCode.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/sms/GetShortCode.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.sms;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting the short code based on the Sid.
@@ -35,7 +37,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetShortCode extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get Short Code");
@@ -44,29 +46,22 @@ public class GetShortCode extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_SHORTCODE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_SMS_SHORTCODES +
-                                    "/" + shortCodeSid,
-                            "GET", null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_SMS_SHORTCODES +
+                        "/" +
+                        shortCodeSid
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
 
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0007", messageContext);
-            throw new SynapseException(e);
-        }
         log.auditLog("End: get Short Code");
     }
 

--- a/src/main/java/org/wso2/carbon/connector/twilio/sms/GetSms.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/sms/GetSms.java
@@ -19,15 +19,17 @@ package org.wso2.carbon.connector.twilio.sms;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a an SMS resource given its Sid.
@@ -35,7 +37,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetSms extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get SMS Status");
@@ -44,28 +46,21 @@ public class GetSms extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_MESSAGE_SID);
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_SMS_MESSAGES +
-                                    "/" + messageSid, "GET",
-                            null);
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_SMS_MESSAGES +
+                        "/" + messageSid
+        );
+        Response response = twilioRestClient.request(request);
 
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0007", messageContext);
-            throw new SynapseException(e);
-        }
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get SMS Status");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/sms/GetSmsList.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/sms/GetSmsList.java
@@ -17,20 +17,23 @@
  */
 package org.wso2.carbon.connector.twilio.sms;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
-import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.Domains;
 
 /*
  * Class mediator for getting a an SMS resource given its Sid.
@@ -38,7 +41,7 @@ import com.twilio.sdk.TwilioRestResponse;
  */
 public class GetSmsList extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) throws ConnectException {
+    public void connect(MessageContext messageContext) {
 
         SynapseLog log = getLog(messageContext);
         log.auditLog("Start: get SMS Status List");
@@ -51,44 +54,43 @@ public class GetSmsList extends AbstractConnector {
         String dateSent =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_DATESENT);
+        String dateSentAfter =
+                (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                        TwilioUtil.PARAM_DATESENTAFTER);
+        String dateSentBefore =
+                (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                        TwilioUtil.PARAM_DATESENTBEFORE);
 
-        try {
-            // the map used for passing parameters
-            Map<String, String> params = new HashMap<String, String>();
+        TwilioUtil.initTwilio(messageContext);
+        TwilioRestClient twilioRestClient = Twilio.getRestClient();
+        Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                TwilioUtil.API_URL +
+                        "/" +
+                        twilioRestClient.getAccountSid() +
+                        "/" +
+                        TwilioUtil.API_SMS_MESSAGES
+        );
 
-            if (to != null) {
-                params.put(TwilioUtil.TWILIO_TO, to);
-            }
-
-            if (from != null) {
-                params.put(TwilioUtil.TWILIO_FROM, from);
-            }
-
-            if (dateSent != null) {
-                // YYYY-MM-DD
-                params.put(TwilioUtil.TWILIO_DATESENT, dateSent);
-            }
-
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            TwilioRestResponse response =
-                    twilioRestClient.request(TwilioUtil.API_URL +
-                                    "/" +
-                                    TwilioUtil.API_VERSION +
-                                    "/" +
-                                    TwilioUtil.API_ACCOUNTS +
-                                    "/" +
-                                    twilioRestClient.getAccountSid() +
-                                    "/" +
-                                    TwilioUtil.API_SMS_MESSAGES,
-                            "GET", params);
-
-            OMElement omResponse = TwilioUtil.parseResponse(response);
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0007", messageContext);
-            throw new SynapseException(e);
+        if (to != null) {
+            request.addQueryParam(TwilioUtil.TWILIO_TO, to);
         }
+
+        if (from != null) {
+            request.addQueryParam(TwilioUtil.TWILIO_FROM, from);
+        }
+
+        if (dateSent != null) {
+            request.addQueryParam(TwilioUtil.TWILIO_DATESENT, dateSent);
+        } else if (dateSentAfter != null || dateSentBefore != null) {
+            request.addQueryDateTimeRange(TwilioUtil.TWILIO_DATESENT,
+                    ZonedDateTime.of(LocalDateTime.parse(dateSentAfter), ZoneId.of("UTC")),
+                    ZonedDateTime.of(LocalDateTime.parse(dateSentBefore), ZoneId.of("UTC")));
+        }
+        Response response = twilioRestClient.request(request);
+
+        OMElement omResponse = TwilioUtil.parseResponse(response);
+        TwilioUtil.preparePayload(messageContext, omResponse);
+
         log.auditLog("End: get SMS Status List");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/sms/SendSms.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/sms/SendSms.java
@@ -17,20 +17,17 @@
  */
 package org.wso2.carbon.connector.twilio.sms;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.SynapseLog;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 import org.wso2.carbon.connector.twilio.util.TwilioUtil;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.resource.factory.SmsFactory;
-import com.twilio.sdk.resource.instance.Sms;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.rest.api.v2010.account.MessageCreator;
 
 /*
  * Class mediator for sending an SMS.
@@ -51,10 +48,6 @@ public class SendSms extends AbstractConnector {
         String body =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_BODY);
-        // optional parameters
-        // see
-        // http://www.twilio.com/docs/api/rest/sending-sms#post-parameters-optional
-        // for more details.
         String statusCallBackUrl =
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_STATUS_CALLBACK_URL);
@@ -62,35 +55,22 @@ public class SendSms extends AbstractConnector {
                 (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                         TwilioUtil.PARAM_APPLICATION_SID);
 
-        // the map used for passing parameters
-        Map<String, String> params = new HashMap<String, String>();
-        // add the optional parameters to the map
-        params.put(TwilioUtil.TWILIO_TO, to);
-        params.put(TwilioUtil.TWILIO_FROM, from);
-        params.put(TwilioUtil.TWILIO_BODY, body);
-
+        TwilioUtil.initTwilio(messageContext);
+        MessageCreator messageCreator = Message.creator(new com.twilio.type.PhoneNumber(to),
+                new com.twilio.type.PhoneNumber(from), body);
         if (applicationSid != null) {
-            params.put(TwilioUtil.TWILIO_APPLICATION_SID, applicationSid);
+            messageCreator.setApplicationSid(applicationSid);
         }
         if (statusCallBackUrl != null) {
-            params.put(TwilioUtil.TWILIO_STATUS_CALLBACK, statusCallBackUrl);
+            messageCreator.setStatusCallback(URI.create(statusCallBackUrl));
         }
+        Message message = messageCreator.create();
 
-        try {
-            TwilioRestClient twilioRestClient = TwilioUtil.getTwilioRestClient(messageContext);
-            // Creates a SMS and sends it
-            SmsFactory messageFactory = twilioRestClient.getAccount().getSmsFactory();
-            Sms message = messageFactory.create(params);
+        OMElement omResponse = TwilioUtil.parseResponse("sms.create.success");
+        TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_MESSAGE_SID, message.getSid());
+        TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_STATUS, message.getStatus().toString());
+        TwilioUtil.preparePayload(messageContext, omResponse);
 
-            OMElement omResponse = TwilioUtil.parseResponse("sms.create.success");
-            TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_MESSAGE_SID, message.getSid());
-            TwilioUtil.addElement(omResponse, TwilioUtil.PARAM_STATUS, message.getStatus());
-            TwilioUtil.preparePayload(messageContext, omResponse);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            TwilioUtil.handleException(e, "0007", messageContext);
-            throw new SynapseException(e);
-        }
         log.auditLog("End: send SMS");
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/twilio/util/TwilioUtil.java
+++ b/src/main/java/org/wso2/carbon/connector/twilio/util/TwilioUtil.java
@@ -28,21 +28,17 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axiom.soap.SOAPBody;
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseConstants;
-import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
-import org.wso2.carbon.connector.core.ConnectException;
 
-import com.twilio.sdk.TwilioRestClient;
-import com.twilio.sdk.TwilioRestResponse;
+import com.twilio.Twilio;
+import com.twilio.http.Response;
 
 public class TwilioUtil {
 
-    public static final String API_URL = "https://api.twilio.com";
+    public static final String API_URL = "/2010-04-01/Accounts";
     public static final String API_VERSION = "2010-04-01";
-    public static final String API_ACCOUNTS = "Accounts";
     public static final String API_SMS_SHORTCODES = "SMS/ShortCodes";
-    public static final String API_SMS_MESSAGES = "SMS/Messages";
+    public static final String API_SMS_MESSAGES = "Messages";
     public static final String API_AVAILABLE_PHONE_NUMBERS = "AvailablePhoneNumbers";
     public static final String API_TOLLFREE = "TollFree";
     public static final String API_LOCAL = "Local";
@@ -75,6 +71,8 @@ public class TwilioUtil {
     public static final String PARAM_URL = "url";
     public static final String PARAM_METHOD = "method";
     public static final String PARAM_DATESENT = "dateSent";
+    public static final String PARAM_DATESENTAFTER = "dateSentAfter";
+    public static final String PARAM_DATESENTBEFORE = "dateSentBefore";
     public static final String PARAM_BODY = "body";
     public static final String PARAM_STATUS_CALLBACK_URL = "statusCallBackUrl";
     public static final String PARAM_APPLICATION_SID = "applicationSid";
@@ -109,7 +107,7 @@ public class TwilioUtil {
     public static final String PARAM_DISTANCE = "distance";
     public static final String PARAM_PHONENUMBER = "phoneNumber";
     public static final String PARAM_SEND_DIGITS = "sendDigits";
-    public static final String PARAM_IF_MACHINE = "ifMachine";
+    public static final String PARAM_MACHINE_DETECTION = "machineDetection";
     public static final String PARAM_IF_TIMEOUT = "timeout";
     public static final String PARAM_IF_RECORD = "record";
     public static final String PARAM_CALL_SID = "callSid";
@@ -121,6 +119,8 @@ public class TwilioUtil {
     public static final String PARAM_PARENT_CALL_SID = "parentCallSid";
     public static final String PARAM_CONFERENCE_SID = "conferenceSid";
     public static final String PARAM_MUTED = "muted";
+    public static final String PARAM_HOLD = "hold";
+    public static final String PARAM_COACHING = "coaching";
     public static final String PARAM_QUEUE_SID = "queueSid";
     public static final String PARAM_MAX_SIZE = "maxSize";
     public static final String PARAM_AUTHORIZED_CONNECT_APP_SID = "authorizedConnectAppSid";
@@ -136,7 +136,6 @@ public class TwilioUtil {
     public static final String PARAM_CALL_DELAY = "callDelay";
     public static final String PARAM_EXTENSION = "extension";
     public static final String PARAM_OUTGOING_CALLERID = "outgoingCallerId";
-    public static final String PARAM_CATEGORY = "category";
     public static final String PARAM_START_DATE = "startDate";
     public static final String PARAM_END_DATE = "endDate";
     public static final String PARAM_RECURRING = "recurring";
@@ -146,33 +145,13 @@ public class TwilioUtil {
     public static final String PARAM_CALLBACK_URL = "callbackUrl";
     public static final String PARAM_CALLBACK_METHOD = "callbackMethod";
     public static final String PARAM_TRIGGER_VALUE = "triggerValue";
-
     public static final String TWILIO_FRIENDLY_NAME = "FriendlyName";
-    public static final String TWILIO_MAX_SIZE = "MaxSize";
     public static final String TWILIO_STATUS = "Status";
     public static final String TWILIO_SHORT_CODE = "ShortCode";
     public static final String TWILIO_TO = "To";
     public static final String TWILIO_FROM = "From";
-    public static final String TWILIO_URL = "Url";
     public static final String TWILIO_DATESENT = "DateSent";
-    public static final String TWILIO_BODY = "Body";
-    public static final String TWILIO_APPLICATION_SID = "ApplicationSid";
-    public static final String TWILIO_STATUS_CALLBACK = "StatusCallback";
-    public static final String TWILIO_API_VERSION = "ApiVersion";
-    public static final String TWILIO_SMS_URL = "SmsUrl";
-    public static final String TWILIO_SMS_METHOD = "SmsMethod";
-    public static final String TWILIO_SMS_FALLBACKURL = "SmsFallbackUrl";
-    public static final String TWILIO_SMS_FALLBACKMETHOD = "SmsFallbackMethod";
-    public static final String TWILIO_VOICE_URL = "VoiceUrl";
-    public static final String TWILIO_VOICE_METHOD = "VoiceMethod";
-    public static final String TWILIO_VOICE_FALLBACKURL = "VoiceFallbackUrl";
-    public static final String TWILIO_VOICE_FALLBACKMETHOD = "VoiceFallbackMethod";
-    public static final String TWILIO_STATUS_CALLBACKMETHOD = "StatusCallbackMethod";
-    public static final String TWILIO_VOICE_CALLERID_LOOKUP = "VoiceCallerIdLookup";
-    public static final String TWILIO_VOICE_APPLICATION_SID = "VoiceApplicationSid";
-    public static final String TWILIO_SMS_APPLICATION_SID = "SmsApplicationSid";
     public static final String TWILIO_ACCOUNT_SID = "AccountSid";
-    public static final String TWILIO_CALL_SID = "CallSid";
     public static final String TWILIO_AREACODE = "AreaCode";
     public static final String TWILIO_CONTAINS = "Contains";
     public static final String TWILIO_IN_REGION = "InRegion";
@@ -183,56 +162,33 @@ public class TwilioUtil {
     public static final String TWILIO_IN_RATE_CENTER = "InRateCenter";
     public static final String TWILIO_DISTANCE = "Distance";
     public static final String TWILIO_PHONENUMBER = "PhoneNumber";
-    public static final String TWILIO_METHOD = "Method";
-    public static final String TWILIO_FALLBACK_URL = "FallbackUrl";
-    public static final String TWILIO_FALLBACK_METHOD = "FallbackMethod";
-    public static final String TWILIO_SEND_DIGITS = "SendDigits";
-    public static final String TWILIO_IF_MACHINE = "IfMachine";
-    public static final String TWILIO_TIMEOUT = "Timeout";
-    public static final String TWILIO_RECORD = "Record";
     public static final String TWILIO_STARTTIME = "StartTime";
     public static final String TWILIO_PARENT_CALL_SID = "ParentCallSid";
     public static final String TWILIO_DATECREATED = "DateCreated";
     public static final String TWILIO_DATEUPDATED = "DateUpdated";
     public static final String TWILIO_MUTED = "Muted";
-    public static final String TWILIO_SMS_STATUS_CALLBACK = "SmsStatusCallback";
-    public static final String TWILIO_AUTHORIZED_REDIRECT_URL = "AuthorizeRedirectUrl";
-    public static final String TWILIO_DEAUTHORIZED_CALLBACK_URL = "DeauthorizeCallbackUrl";
-    public static final String TWILIO_DEAUTHORIZED_CALLBACK_METHOD = "DeauthorizeCallbackMethod";
-    public static final String TWILIO_PERMISSIONS = "Permissions";
-    public static final String TWILIO_DESCRIPTION = "Description";
-    public static final String TWILIO_COMPANYNAME = "CompanyName";
-    public static final String TWILIO_HOMEPAGE_URL = "HomepageUrl";
-    public static final String TWILIO_CALL_DELAY = "CallDelay";
-    public static final String TWILIO_EXTENSION = "Extension";
+    public static final String TWILIO_HOLD = "Hold";
+    public static final String TWILIO_COACHING = "Coaching";
     public static final String TWILIO_CATEGORY = "Category";
     public static final String TWILIO_START_DATE = "StartDate";
     public static final String TWILIO_END_DATE = "EndDate";
     public static final String TWILIO_RECURRING = "Recurring";
     public static final String TWILIO_USAGE_CATEGORY = "UsageCategory";
     public static final String TWILIO_TRIGGERBY = "TriggerBy";
-    public static final String TWILIO_CALLBACK_URL = "CallbackUrl";
-    public static final String TWILIO_CALLBACK_METHOD = "CallbackMethod";
-    public static final String TWILIO_TRIGGER_VALUE = "TriggerValue";
 
     private static final OMFactory fac = OMAbstractFactory.getOMFactory();
     private static final OMNamespace omNs = fac.createOMNamespace("http://wso2.org/twilio/adaptor",
             "twilio");
 
-    public synchronized static TwilioRestClient getTwilioRestClient(MessageContext messageContext)
-            throws ConnectException {
-        // Authorization details
-        // Get parameters from the messageContext
-        // Getting Transport Headers
+    public static synchronized void initTwilio(MessageContext messageContext) {
         Axis2MessageContext axis2smc = (Axis2MessageContext) messageContext;
-        axis2smc.getAxis2MessageContext();
         String accountSid =
                 (String) axis2smc.getAxis2MessageContext().getOperationContext()
                         .getProperty("twilio.accountSid");
         String authToken =
                 (String) axis2smc.getAxis2MessageContext().getOperationContext()
                         .getProperty("twilio.authToken");
-        return new TwilioRestClient(accountSid, authToken);
+        Twilio.init(accountSid, authToken);
     }
 
     public static OMElement parseResponse(String strMessageKey) {
@@ -248,7 +204,7 @@ public class TwilioUtil {
         Properties prop = new Properties();
         try {
             prop.load(TwilioUtil.class.getResourceAsStream("/messages/message.properties"));
-            return (String) prop.getProperty(strMessageKey);
+            return prop.getProperty(strMessageKey);
         } catch (IOException ex) {
             ex.printStackTrace();
         }
@@ -269,10 +225,10 @@ public class TwilioUtil {
         return omElement;
     }
 
-    public static OMElement parseResponse(TwilioRestResponse restResponse) {
+    public static OMElement parseResponse(Response restResponse) {
         OMElement omElement;
         try {
-            omElement = AXIOMUtil.stringToOM(restResponse.getResponseText());
+            omElement = AXIOMUtil.stringToOM(restResponse.getContent());
         } catch (Exception e) {
             omElement = fac.createOMElement("error", omNs);
             OMElement subValue = fac.createOMElement("errorMessage", omNs);
@@ -300,12 +256,5 @@ public class TwilioUtil {
         subValue.addChild(fac.createOMText(omElement, e.getMessage()));
         omElement.addChild(subValue);
         preparePayload(messageContext, omElement);
-    }
-
-    public static void handleException(Exception e, String erroCode, MessageContext messageContext) {
-        messageContext.setProperty(SynapseConstants.ERROR_EXCEPTION, e);
-        messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, e.getMessage());
-        messageContext.setProperty(SynapseConstants.ERROR_CODE, erroCode);
-        preparePayload(messageContext, e);
     }
 }


### PR DESCRIPTION
## Purpose
> Current Twilio SDK version is getting deprecated on November 28, 2022 and the version should be updated to the latest.

## Goals
> Migrate into the latest Twilio SDK version

## Related Issues
https://github.com/wso2/api-manager/issues/753